### PR TITLE
Use default file dialog for MAD export + SMD export menu option.

### DIFF
--- a/Libraries/EDItors/Sources/OUTput/OUTframe_act.cpp
+++ b/Libraries/EDItors/Sources/OUTput/OUTframe_act.cpp
@@ -415,54 +415,34 @@ void EOUT_cl_Frame::OnAction(ULONG _ul_Action)
 
 	/*$1-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
-	case EOUT_ACTION_EXPORTWORLDTOMAD:
+		case EOUT_ACTION_EXPORTWORLDTOMADSKIN:
+		case EOUT_ACTION_EXPORTWORLDTOMAD:
 		{
-			if(cl_ChooseFile.DoModal() == IDOK)
+			CFileDialog file( FALSE, _T("mad"), 0, 0, _T("Mad Files (*.mad)|*.mad|All Files (*.*)|*.*||"), this );
+			if ( file.DoModal() == IDOK )
 			{
-				L_strcpy(sz_FileName, cl_ChooseFile.masz_FullPath);
-				psz_EndPath = sz_FileName + L_strlen(sz_FileName);
-				if(*(psz_EndPath - 1) != '/') *psz_EndPath++ = '/';
-
-				cl_ChooseFile.GetItem(cl_ChooseFile.mo_File, 1, o_Temp);
-				strcpy(psz_EndPath, (char *) (LPCSTR) o_Temp);
-
-				psz_EndPath = strrchr(sz_FileName, '.');
-				if(!psz_EndPath || (L_stricmp(psz_EndPath, ".mad")))
+				CString filePath = file.GetPathName();
+				if ( !filePath.IsEmpty() )
 				{
-					psz_EndPath = sz_FileName + L_strlen(sz_FileName);
-					strcpy(psz_EndPath, ".mad");
+					DP()->ExportWorldToMad( filePath.GetString(), ( _ul_Action == EOUT_ACTION_EXPORTWORLDTOMADSKIN ) );
 				}
-
-				DP()->ExportWorldToMad(sz_FileName, FALSE);
 			}
+			break;
 		}
-		break;
 
-	/*$1-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-
-	case EOUT_ACTION_EXPORTWORLDTOMADSKIN:
+		case EOUT_ACTION_EXPORT_SMD:
 		{
-			if(cl_ChooseFile.DoModal() == IDOK)
+			CFolderPickerDialog file( nullptr, 0, this );
+			if ( file.DoModal() == IDOK )
 			{
-				L_strcpy(sz_FileName, cl_ChooseFile.masz_FullPath);
-				psz_EndPath = sz_FileName + L_strlen(sz_FileName);
-				if(*(psz_EndPath - 1) != '/') *psz_EndPath++ = '/';
-
-				cl_ChooseFile.GetItem(cl_ChooseFile.mo_File, 1, o_Temp);
-				strcpy(psz_EndPath, (char *) (LPCSTR) o_Temp);
-
-				psz_EndPath = strrchr(sz_FileName, '.');
-				if(!psz_EndPath || (L_stricmp(psz_EndPath, ".mad")))
+				CString folder = file.GetPathName();
+				if ( !folder.IsEmpty() )
 				{
-					psz_EndPath = sz_FileName + L_strlen(sz_FileName);
-					strcpy(psz_EndPath, ".mad");
+					DP()->ExportWorldToSmd( folder.GetString(), true );
 				}
-
-				DP()->ExportWorldToMad(sz_FileName, TRUE);
 			}
+			break;
 		}
-		break;
-
 
 	/*$1-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
@@ -3551,12 +3531,14 @@ BOOL EOUT_cl_Frame::b_OnActionValidate(ULONG _ul_Action, BOOL _b_Disp)
 
 	case EOUT_ACTION_SAVEWORLD:
 	case EOUT_ACTION_SAVEWORLDDUPLICATERLI:
+	case EOUT_ACTION_SAVEWORLDONLYSELECTED:
 	case EOUT_ACTION_EXPORTWORLDTOMAD:
 	case EOUT_ACTION_EXPORTWORLDTOMADSKIN:
 	case EOUT_ACTION_EXPORTONLYSELECTED:
 	case EOUT_ACTION_EXPORTTEXTURE:
 	case EOUT_ACTION_EXPORTQUICK:
 	case EOUT_ACTION_EXPORTDIR:
+	case EOUT_ACTION_EXPORT_SMD:
 		return(DW() != NULL);
 
 	case EOUT_ACTION_EXPORTWORLDTOASSOCIATEDMAD:

--- a/Libraries/EDItors/Sources/OUTput/OUTframe_act.h
+++ b/Libraries/EDItors/Sources/OUTput/OUTframe_act.h
@@ -373,6 +373,8 @@
 #define EOUT_ACTION_COMPUTETSS_GROUP4            826
 #define EOUT_ACTION_COMPUTEFIX_RLI               827
 
+#define EOUT_ACTION_EXPORT_SMD	900
+
 /* dynamic menu id */
 #define EOUT_SEPACTION_WORLD	- 1
 #define EOUT_SEPACTION_CAMERA	- 2
@@ -801,6 +803,7 @@ Export Dir =5=--=0;\
 Old Export World To Mad...=6=--=0;\
 Export World To Mad...=705=--=0;\
 Export World To =7=--=0;\
+Export To SMD...=900=--=0;\
 Quick Export=8=--=0;\
 Sep=0=--=0;\
 Close World=9=^F4=0;\

--- a/Libraries/ENGine/Make/ENGine.vcxproj
+++ b/Libraries/ENGine/Make/ENGine.vcxproj
@@ -673,6 +673,7 @@
     <ClInclude Include="..\Sources\WORld\WORaccess.h" />
     <ClInclude Include="..\Sources\WORld\WORcheck.h" />
     <ClInclude Include="..\Sources\WORld\WORconst.h" />
+    <ClInclude Include="..\Sources\WORld\WORexport.h" />
     <ClInclude Include="..\Sources\WORld\WORexporttomad.h" />
     <ClInclude Include="..\Sources\WORld\WORimportfrommad.h" />
     <ClInclude Include="..\Sources\WORld\WORinit.h" />

--- a/Libraries/ENGine/Make/ENGine.vcxproj.filters
+++ b/Libraries/ENGine/Make/ENGine.vcxproj.filters
@@ -883,6 +883,9 @@
       <Filter>Wind</Filter>
     </ClInclude>
     <ClInclude Include="..\Sources\Precomp.h" />
+    <ClInclude Include="..\Sources\WORld\WORexport.h">
+      <Filter>WORld</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="..\Sources\MoDiFier\MDFmodifier_Wind.h">

--- a/Libraries/ENGine/Sources/WORld/WORexport.cpp
+++ b/Libraries/ENGine/Sources/WORld/WORexport.cpp
@@ -17,23 +17,32 @@ void WorldExporter::ExportTextures( const char *outDir )
 		TEX_tdst_Data *textureData = &TEX_gst_GlobalList.dst_Texture[ i ];
 		unsigned int index         = BIG_ul_SearchKeyToFat( textureData->ul_Key );
 		if ( index == BIG_C_InvalidKey )
+		{
 			continue;
+		}
 
 		const char *name = BIG_NameFile( index );
 		assert( name != nullptr );
 		if ( name == nullptr )
+		{
 			continue;
+		}
 
 		const char *extension = strrchr( name, '.' );
 		assert( extension != nullptr );
 		if ( extension == nullptr )
+		{
 			continue;
+		}
+
+		TEX_tdst_File_Desc desc;
+		BAS_ZERO( &desc, sizeof( desc ) );
 
 		std::string outPath = outDir;
 		if ( stricmp( extension, ".tex" ) == 0 )
 		{
-			TEX_tdst_File_Desc desc;
 			TEX_l_File_GetInfoAndContent( textureData->ul_Key, &desc );
+			//TODO
 		}
 		else if ( stricmp( extension, ".tga" ) == 0 )
 		{
@@ -56,6 +65,8 @@ void WorldExporter::ExportTextures( const char *outDir )
 			assert( 0 );
 			continue;
 		}
+
+		TEX_File_FreeDescription( &desc );
 	}
 }
 

--- a/Libraries/ENGine/Sources/WORld/WORexport.cpp
+++ b/Libraries/ENGine/Sources/WORld/WORexport.cpp
@@ -46,7 +46,7 @@ void WorldExporter::ExportTextures( const char *outDir )
 		{
 			//TODO
 		}
-		else if (stricmp(extension, ".raw") == 0)
+		else if ( stricmp( extension, ".raw" ) == 0 )
 		{
 			//TODO
 		}
@@ -59,7 +59,7 @@ void WorldExporter::ExportTextures( const char *outDir )
 	}
 }
 
-bool MADExporter::ExportFile( WOR_tdst_World *world, const char *filename, const char *exportDir, unsigned char sel, bool textures )
+bool MADExporter::ExportFile( WOR_tdst_World *world, const char *filename, const char *exportDir, bool selected, bool textures )
 {
 	Mad_meminit();
 
@@ -68,25 +68,28 @@ bool MADExporter::ExportFile( WOR_tdst_World *world, const char *filename, const
 	return false;
 }
 
-bool GLTFExporter::ExportFile( WOR_tdst_World *world, const char *filename, const char *exportDir, unsigned char sel, bool textures )
+bool GLTFExporter::ExportFile( WOR_tdst_World *world, const char *filename, const char *exportDir, bool selected, bool textures )
 {
 	return false;
 }
 
-bool SMDExporter::ExportFile( WOR_tdst_World *world, const char *filename, const char *exportDir, unsigned char sel, bool textures )
+bool SMDExporter::ExportFile( WOR_tdst_World *world, const char *filename, const char *exportDir, bool selected, bool textures )
 {
+	//TODO: bones + animations aren't currently dealt with here, I'd decided it wasn't yet worth the effort so I'll look at it later
+
+	assert( exportDir != nullptr );
+
 	TAB_PFtable_RemoveHoles( &world->st_AllWorldObjects );
 	TAB_tdst_PFelem *element    = TAB_pst_PFtable_GetFirstElem( &world->st_AllWorldObjects );
 	TAB_tdst_PFelem *endElement = TAB_pst_PFtable_GetLastElem( &world->st_AllWorldObjects );
 	for ( unsigned int i = 0; element <= endElement; element++, i++ )
 	{
 		OBJ_tdst_GameObject *gameObject = ( OBJ_tdst_GameObject * ) element->p_Pointer;
-		if ( gameObject == nullptr )
+		if ( gameObject == nullptr || ( selected && !( gameObject->ul_EditorFlags & OBJ_C_EditFlags_Selected ) ) )
 		{
 			continue;
 		}
 
-		std::string name    = gameObject->sz_Name;
 		OBJ_tdst_Base *base = gameObject->pst_Base;
 		if ( base == nullptr )
 		{
@@ -120,13 +123,13 @@ bool SMDExporter::ExportFile( WOR_tdst_World *world, const char *filename, const
 			continue;
 		}
 
-		//TEMP: as the name implies, this is just temporary for testing!!!
-		std::string tmp = "./" + name + ".smd";
+		// assumed to be a dir here, due to the fact that an SMD can't hold multiple meshes!
+		std::string outname = std::string( exportDir ) + "/" + std::string( gameObject->sz_Name ) + ".smd";
 
-		FILE *out = fopen( tmp.c_str(), "w" );
+		FILE *out = fopen( outname.c_str(), "w" );
 		if ( out == nullptr )
 		{
-			std::string msg = "Failed to create SMD file (" + tmp + ")!";
+			std::string msg = "Failed to create SMD file (" + outname + ")!";
 			LINK_PrintStatusMsg( ( char * ) msg.c_str() );
 			continue;
 		}
@@ -145,7 +148,10 @@ bool SMDExporter::ExportFile( WOR_tdst_World *world, const char *filename, const
 
 			for ( unsigned int k = 0; k < element->l_NbTriangles; ++k )
 			{
-				fprintf( out, "test.bmp\n" );
+				const char *materialName = GRO_sz_Struct_GetName( &material->st_Id );
+				assert( materialName != nullptr );
+				fprintf( out, "%s.bmp\n", materialName );
+
 				const GEO_tdst_IndexedTriangle *tri = &element->dst_Triangle[ k ];
 				for ( unsigned int l = 0; l < 3; ++l )
 				{

--- a/Libraries/ENGine/Sources/WORld/WORexport.h
+++ b/Libraries/ENGine/Sources/WORld/WORexport.h
@@ -6,7 +6,7 @@ public:
 	WorldExporter()  = default;
 	~WorldExporter() = default;
 
-	virtual bool ExportFile( WOR_tdst_World *world, const char *filename, const char *exportDir, unsigned char sel, bool textures ) = 0;
+	virtual bool ExportFile( WOR_tdst_World *world, const char *filename, const char *exportDir, bool selected = false, bool textures = false ) = 0;
 
 	static void ExportTextures( const char *outDir );
 };
@@ -14,7 +14,7 @@ public:
 class MADExporter : public WorldExporter
 {
 public:
-	bool ExportFile( WOR_tdst_World *world, const char *filename, const char *exportDir, unsigned char sel, bool textures ) override;
+	bool ExportFile( WOR_tdst_World *world, const char *filename, const char *exportDir, bool selected, bool textures ) override;
 };
 
 class SMDExporter : public WorldExporter
@@ -23,11 +23,11 @@ public:
 	SMDExporter()  = default;
 	~SMDExporter() = default;
 
-	bool ExportFile( WOR_tdst_World *world, const char *filename, const char *exportDir, unsigned char sel, bool textures ) override;
+	bool ExportFile( WOR_tdst_World *world, const char *filename, const char *exportDir, bool selected, bool textures ) override;
 };
 
 class GLTFExporter : public WorldExporter
 {
 public:
-	bool ExportFile( WOR_tdst_World *world, const char *filename, const char *exportDir, unsigned char sel, bool textures ) override;
+	bool ExportFile( WOR_tdst_World *world, const char *filename, const char *exportDir, bool selected, bool textures ) override;
 };

--- a/Main/WinEditors/Sources/F3Dframe/F3Dview.h
+++ b/Main/WinEditors/Sources/F3Dframe/F3Dview.h
@@ -319,7 +319,10 @@ public:
 	void							  LogUnCollidable(void);
 	void							  SaveWorld(bool onlySelected = false);
 	void							  NewWorld(void);
-	void							  ExportWorldToMad(char *, BOOL);
+
+	void ExportWorldToMad( const char *, BOOL );
+	void ExportWorldToSmd( const char *, bool );
+
 	void							  DropMaterial(EDI_tdst_DragDrop *);
 
 	void							  DropGameObject(EDI_tdst_DragDrop *,BOOL);

--- a/Main/WinEditors/Sources/F3Dframe/F3Dview_wor.cpp
+++ b/Main/WinEditors/Sources/F3Dframe/F3Dview_wor.cpp
@@ -16,6 +16,7 @@
 #include "ENGine/Sources/WORld/WORsave.h"
 #include "ENGine/Sources/WORld/WORinit.h"
 #include "ENGine/Sources/WORld/WORexporttomad.h"
+#include "ENGine/Sources/WORld/WORexport.h"
 #include "BIGfiles/BIGmdfy_dir.h"
 #include "GEOmetric/GEOload.h"
 #include "F3Dframe/F3Dview.h"
@@ -1147,19 +1148,38 @@ void F3D_cl_View::AssignMaterial(OBJ_tdst_GameObject* _pst_GO, BIG_INDEX _ul_Ind
  =======================================================================================================================
  =======================================================================================================================
  */
-void F3D_cl_View::ExportWorldToMad(char *_sz_FileName, BOOL _b_ExportSkin)
+void F3D_cl_View::ExportWorldToMad(const char *_sz_FileName, BOOL _b_ExportSkin)
 {
     if(mst_WinHandles.pst_World == NULL) return;
-    strcpy(msz_AssociatedMadFile, _sz_FileName);
-    WOR_b_World_ExportMadFile
-        (
-            mst_WinHandles.pst_World, 
-            msz_AssociatedMadFile, 
-            msz_ExportDir, 
-            ((EOUT_cl_Frame *) mpo_AssociatedEditor)->mst_Ini.uc_ExportOnlySelection, 
-            ((EOUT_cl_Frame *) mpo_AssociatedEditor)->mst_Ini.uc_ExportTexture,
-            _b_ExportSkin
-        );
+	snprintf( msz_AssociatedMadFile, sizeof( msz_AssociatedMadFile ), "%s", _sz_FileName );
+	if (!WOR_b_World_ExportMadFile
+	(
+		mst_WinHandles.pst_World,
+		msz_AssociatedMadFile,
+		msz_ExportDir,
+		((EOUT_cl_Frame*)mpo_AssociatedEditor)->mst_Ini.uc_ExportOnlySelection,
+		((EOUT_cl_Frame*)mpo_AssociatedEditor)->mst_Ini.uc_ExportTexture,
+		_b_ExportSkin
+	))
+	{
+		MessageBox( "MAD export failed! Check console for details.", "Warning", MB_OK | MB_ICONWARNING );
+	}
+}
+
+void F3D_cl_View::ExportWorldToSmd( const char *filename, bool skin )
+{
+	if ( mst_WinHandles.pst_World == nullptr )
+	{
+		return;
+	}
+
+	SMDExporter smdExport;
+	if ( !smdExport.ExportFile( mst_WinHandles.pst_World, nullptr, filename,
+		((EOUT_cl_Frame*)mpo_AssociatedEditor)->mst_Ini.uc_ExportOnlySelection,
+		((EOUT_cl_Frame*)mpo_AssociatedEditor)->mst_Ini.uc_ExportTexture))
+	{
+		MessageBox( "SMD export failed! Check console for details.", "Warning", MB_OK | MB_ICONWARNING );
+	}
 }
 
 /*


### PR DESCRIPTION
We're also now including material names in the SMD, though I'm not sure if this is the best solution but it's a little awkward given materials can have multiple texture slots... So eh. Bones are still not done.